### PR TITLE
Adding OMV 3.0.95 compatible instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,14 +11,24 @@ cd openmediavault-monitoring-odroid-xu4-master
 cp -R usr/* /usr
 cp -R var/* /var
 rm -r /tmp/openmediavault-monitoring-odroid-xu4-master
+cd /
 
 chmod +x /usr/local/bin/cputemp /usr/share/openmediavault/mkconf/collectd.d/cpu{freq,temp}
 omv-mkconf collectd
 
-chown openmediavault:openmediavault /var/www/openmediavault/js/omv/module/admin/diagnostic/system/plugin/Cpu{Temperature,Frequency}.js
+chown openmediavault-webgui:openmediavault-webgui /var/www/openmediavault/js/omv/module/admin/diagnostic/system/plugin/Cpu{Temperature,Frequency}.js
 chmod 644 /var/www/openmediavault/js/omv/module/admin/diagnostic/system/plugin/Cpu{Temperature,Frequency}.js
 
 source /usr/share/openmediavault/scripts/helper-functions && omv_purge_internal_cache
+
+# optionally add the below two lines without # symbols to /etc/default/openmediavault
+# OMV_COLLECTD_RRDTOOL_GRAPH_WIDTH=800
+# OMV_COLLECTD_RRDTOOL_GRAPH_HEIGHT=200
+
+omv-mkconf collectd
+omv-mkconf rrdcached
+
+reboot
 ```
 
 ## Examples


### PR DESCRIPTION
Hi, 

Your extension is superb, thanks!
However, it needed some polishing to make it compatible with the most recent OMV version (or generally OMV3).

- `L14`: omv-mkconf throws an error if the terminal is still in the non-existent folder.
- `L19`: the webgui user has a different name and group now
- `L23-31`: included the additional commands from your website

Cheers